### PR TITLE
Rtc extra functions

### DIFF
--- a/src/RTC_container.cpp
+++ b/src/RTC_container.cpp
@@ -17,7 +17,7 @@ int8_t RTC_container::check_datetime(){
 int8_t RTC_container::setup(){
   Wire.begin();
   int8_t status = 0;
-  int32_t seconds = 120;
+  this->sleep_time = 90; // TODO set for field interval (15m) before deploying.
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     status = -1;
@@ -30,69 +30,41 @@ int8_t RTC_container::setup(){
   rtc.armAlarm(2, false);
   rtc.clearAlarm(2);
   rtc.alarmInterrupt(2, false);
-
   //set mode; set alarm; arm interrupt
-  //TODO: change to set next alarm on interval from current time
   rtc.writeSqwPinMode(DS3231_OFF);
-  //rtc.setAlarm(ALM1_MATCH_SECONDS, 0, 0, 0, 0);
-
-  printf("%d\n", seconds );
-  Serial.println("Current time: ");
-  this->print_date();
-  Serial.println("Next wake time: ");
-  this->set_next_alarm(seconds, 1);
+  this->set_next_alarm(this->sleep_time, 1);
   rtc.alarmInterrupt(1, true);
-
   return(status);
 }
 
-void RTC_container::print_date(){
-    DateTime now = rtc.now();
+void RTC_container::print_date(DateTime t){
     Serial.println();
-    Serial.print(now.year(), DEC);
+    Serial.print(t.year(), DEC);
     Serial.print('/');
-    Serial.print(now.month(), DEC);
+    Serial.print(t.month(), DEC);
     Serial.print('/');
-    Serial.print(now.day(), DEC);
+    Serial.print(t.day(), DEC);
     Serial.print(" (");
-    Serial.print(daysOfTheWeek[now.dayOfTheWeek()]);
+    Serial.print(daysOfTheWeek[t.dayOfTheWeek()]);
     Serial.print(") ");
-    Serial.print(now.hour(), DEC);
+    Serial.print(t.hour(), DEC);
     Serial.print(':');
-    Serial.print(now.minute(), DEC);
+    Serial.print(t.minute(), DEC);
     Serial.print(':');
-    Serial.print(now.second(), DEC);
+    Serial.print(t.second(), DEC);
     Serial.println();
     Serial.println();
 }
 
-// TODO fill out this method
+//TODO clean out print statements before deploying.
 int8_t RTC_container::set_next_alarm(int32_t seconds, int8_t alarm_num){
   int8_t status = 0;
   DateTime now = rtc.now();
-  long now_seconds = now.secondstime();
-  //Serial.printf("%ld  %d\n", (long)seconds, seconds);
-  Serial.printf("%ld\n", now_seconds );
-  now_seconds += (long) seconds;
-  Serial.printf("%ld\n", now_seconds );
-  //DateTime next_alarm = DateTime(now_seconds);
+  Serial.println("Current time: ");
+  this->print_date(now);
+  Serial.println("Next wake time: ");
   DateTime next_alarm = now + seconds;
-    Serial.println();
-    Serial.print(next_alarm.year(), DEC);
-    Serial.print('/');
-    Serial.print(next_alarm.month(), DEC);
-    Serial.print('/');
-    Serial.print(next_alarm.day(), DEC);
-    Serial.print(" (");
-    Serial.print(daysOfTheWeek[next_alarm.dayOfTheWeek()]);
-    Serial.print(") ");
-    Serial.print(next_alarm.hour(), DEC);
-    Serial.print(':');
-    Serial.print(next_alarm.minute(), DEC);
-    Serial.print(':');
-    Serial.print(next_alarm.second(), DEC);
-    Serial.println();
-    Serial.println();
+  this->print_date(next_alarm);
   if (alarm_num == 1) {
     rtc.setAlarm(ALM1_MATCH_HOURS, next_alarm.second(), next_alarm.minute(),
       next_alarm.hour(), next_alarm.day());

--- a/src/RTC_container.cpp
+++ b/src/RTC_container.cpp
@@ -1,17 +1,28 @@
 #include "RTC_container.h"
 
+int8_t RTC_container::check_datetime(){
+  int8_t status;
+  Serial.println("Checking RTC time...");
+  if (this->rtc.lostPower()) {
+    Serial.println("RTC lost power; resetting to compile time.");
+    this->rtc.adjust(DateTime(F(__DATE__), F(__TIME__)));
+    status = 1;
+  } else {
+    Serial.println("RTC time is OK!");
+    status = 0;
+  }
+  return(status);
+}
+
 int8_t RTC_container::setup(){
+  Wire.begin();
   int8_t status = 0;
+  int32_t seconds = 120;
   if (! rtc.begin()) {
     Serial.println("Couldn't find RTC");
     status = -1;
     return(status);
   }
-  if (rtc.lostPower()) {
-    Serial.println("RTC lost power; resetting to compile time.");
-    rtc.adjust(DateTime(F(__DATE__), F(__TIME__)));
-  }
-
   //clear alarms before we initialize
   rtc.armAlarm(1, false);
   rtc.clearAlarm(1);
@@ -23,7 +34,13 @@ int8_t RTC_container::setup(){
   //set mode; set alarm; arm interrupt
   //TODO: change to set next alarm on interval from current time
   rtc.writeSqwPinMode(DS3231_OFF);
-  rtc.setAlarm(ALM1_MATCH_SECONDS, 0, 0, 0, 0);
+  //rtc.setAlarm(ALM1_MATCH_SECONDS, 0, 0, 0, 0);
+
+  printf("%d\n", seconds );
+  Serial.println("Current time: ");
+  this->print_date();
+  Serial.println("Next wake time: ");
+  this->set_next_alarm(seconds, 1);
   rtc.alarmInterrupt(1, true);
 
   return(status);
@@ -50,7 +67,38 @@ void RTC_container::print_date(){
 }
 
 // TODO fill out this method
-int8_t RTC_container::set_next_alarm(int8_t seconds){
+int8_t RTC_container::set_next_alarm(int32_t seconds, int8_t alarm_num){
   int8_t status = 0;
+  DateTime now = rtc.now();
+  long now_seconds = now.secondstime();
+  //Serial.printf("%ld  %d\n", (long)seconds, seconds);
+  Serial.printf("%ld\n", now_seconds );
+  now_seconds += (long) seconds;
+  Serial.printf("%ld\n", now_seconds );
+  //DateTime next_alarm = DateTime(now_seconds);
+  DateTime next_alarm = now + seconds;
+    Serial.println();
+    Serial.print(next_alarm.year(), DEC);
+    Serial.print('/');
+    Serial.print(next_alarm.month(), DEC);
+    Serial.print('/');
+    Serial.print(next_alarm.day(), DEC);
+    Serial.print(" (");
+    Serial.print(daysOfTheWeek[next_alarm.dayOfTheWeek()]);
+    Serial.print(") ");
+    Serial.print(next_alarm.hour(), DEC);
+    Serial.print(':');
+    Serial.print(next_alarm.minute(), DEC);
+    Serial.print(':');
+    Serial.print(next_alarm.second(), DEC);
+    Serial.println();
+    Serial.println();
+  if (alarm_num == 1) {
+    rtc.setAlarm(ALM1_MATCH_HOURS, next_alarm.second(), next_alarm.minute(),
+      next_alarm.hour(), next_alarm.day());
+  } else if (alarm_num == 2) { // seconds is always 0 on alarm 2!
+    rtc.setAlarm(ALM2_MATCH_HOURS, 0, next_alarm.minute(),
+      next_alarm.hour(), next_alarm.day());
+  }
   return(status);
 }

--- a/src/RTC_container.h
+++ b/src/RTC_container.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "pins.h"
+#include <Wire.h>
 #include "RTClibExtended.h"
 
 /**
@@ -14,6 +15,18 @@
  */
 class RTC_container {
 public:
+
+  /**
+  *   \brief Update RTC date/time if needed.
+  *
+  *   \return status An int (0 -> no change, 1 -> change, other -> error)
+  *
+  *   This check will only take place when the system isn't woken up
+  *   from deep sleep (e.g. it is first powered on).
+  *   TODO are there other cases we need to check?
+  */
+
+  int8_t check_datetime();
 
   /**
   *   \brief Print out the current time.
@@ -39,7 +52,7 @@ public:
   *   RTC which can only take one second intervals or some
   *   future time to set an alarm.
   */
-  int8_t set_next_alarm(int8_t seconds);
+  int8_t set_next_alarm(int32_t seconds, int8_t alarm_num);
 
 private:
 

--- a/src/RTC_container.h
+++ b/src/RTC_container.h
@@ -25,14 +25,14 @@ public:
   *   from deep sleep (e.g. it is first powered on).
   *   TODO are there other cases we need to check?
   */
-
   int8_t check_datetime();
 
   /**
-  *   \brief Print out the current time.
+  *   \brief Print out the contents of a DateTime (human readable).
+  *   \param t A DateTime object.
   *
   */
-  void print_date();
+  void print_date(DateTime t);
 
   /**
   *   \brief Prepare the RTC for operation.
@@ -74,4 +74,14 @@ private:
   *   field operations.
   */
   char daysOfTheWeek[7][12] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
+
+  /**
+  *   \var sleep_time
+  *   \brief Sleep time in seconds between sensor readings
+  *
+  *   The RTC sends a signal to wake the chip so that it can take readings
+  *   from the sensors. This field sets the length of time between signals.
+  *
+  */
+  int32_t sleep_time;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@ void handle_wakeup(RTC_container clock){
   switch(reason){
     case 1  :
       Serial.println("Wakeup caused by external signal using RTC_IO (Interrupt from RTC)");
-      clock.print_date();
+      //clock.print_date();
       break;
     case 2  :
       Serial.println("Wakeup caused by external signal using RTC_CNTL");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,8 @@ void handle_wakeup(RTC_container clock){
       break;
     default :
       Serial.println("Wakeup was not caused by deep sleep");
+      int8_t clock_status;
+      clock_status = clock.check_datetime();
       break;
     }
 }
@@ -38,10 +40,10 @@ void enter_sleep(){
 void setup () {
   Serial.begin(115200);
   Wire.begin(); // this prevents some time weirdness from rtc
-  RTC_container clock;
-  clock.setup();
   delay(1000); // wait for console opening
+  RTC_container clock;
   handle_wakeup(clock); //do whatever it is we do when we wake up
+  clock.setup();
 
   // TemperatureSensor setup and read
   TemperatureSensor ts;


### PR DESCRIPTION
This branch adds the ability to set odd intervals for alarm wakeup (not just matching on seconds, mins, etc) by adding the specified interval onto the current time and setting the next alarm with this value.  
  
I had to rearrange main a little (unfortunately) because we need to check whether our clock has been interrupted on first waking. In addition, we will need to write something later that allows us to precisely set our clock's time. This will probably require a simple separate program that is run shortly before we upload the 'real' code for field deployment.  
  
Let's try to discuss this pull request tomorrow (tuesday) if we can.